### PR TITLE
Add Flatpak to downloads

### DIFF
--- a/download/index.md
+++ b/download/index.md
@@ -15,12 +15,12 @@ The best way to play Red Eclipse is by downloading it through <span class="fab f
 
 ### Binary Bundles
 
-If you'd rather not use <span class="fab fa-steam" aria-hidden="true"></span> **Steam** (as described above), you can still download a static installable package below. Note that only the Linux AppImage provides automatic updates, any other version will require you to update your installation manually each release.
+If you'd rather not use <span class="fab fa-steam" aria-hidden="true"></span> **Steam** (as described above), you can still download a static installable package below. Note that only the Linux AppImage and Linux Flatpak provides automatic updates, any other version will require you to update your installation manually each release.
 
 Platform                                                             | Downloads                           | Other Sources
 ---------------------------------------------------------------------|-------------------------------------|-------------------------------------
 <span class="fab fa-windows" aria-hidden="true"></span> **Windows**  | **[Installer](/download/win)**      | [Torrent](/download/torrent/win) - [ZIP](/download/zip)
-<span class="fab fa-linux" aria-hidden="true"></span> **Linux/BSD**  | **[TAR.BZ2](/download/nix)**        | [Torrent](/download/torrent/nix) - [AppImage](/download/appimage)
+<span class="fab fa-linux" aria-hidden="true"></span> **Linux/BSD**  | **[TAR.BZ2](/download/nix)**        | [Torrent](/download/torrent/nix) - [AppImage](/download/appimage) - [Flatpak](https://flathub.org/apps/details/net.redeclipse.RedEclipse)
 <span class="fab fa-apple" aria-hidden="true"></span> **macOS**      | **[TAR.BZ2](/download/mac)**        | [Torrent](/download/torrent/mac)
 <span class="fas fa-archive" aria-hidden="true"></span> **Combined** | **[TAR.BZ2](/download/combined)**   | [Torrent](/download/torrent/combined)
 


### PR DESCRIPTION
This adds a link to the Red Eclipse Flatpak on Flathub.

Flatpak is one of the newer distribution-agnostic packaging formats for Linux, which has strong support from e.g. Red Hat, KDE and Gnome


https://flathub.org/apps/details/net.redeclipse.RedEclipse

https://github.com/flathub/net.redeclipse.RedEclipse

https://flatpak.org

