### PR TITLE
Fix docs link - /wiki --> /docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@ redirect_from:
 </div>
 <div class="row texte">
     <div class="col-xs-12 col-sm-4 col-md-4">
-        <p>{{ site.title }} is a fun-filled new take on the first person arena shooter, featuring parkour, impulse boosts, and more. The development is geared toward balanced gameplay, with a general theme of agility in a variety of environments. For more information, please see our <a href="/wiki">Documentation</a>, <a href="/discord">Discord</a> or <a href="/discuss">Discussions</a>.</p>
+        <p>{{ site.title }} is a fun-filled new take on the first person arena shooter, featuring parkour, impulse boosts, and more. The development is geared toward balanced gameplay, with a general theme of agility in a variety of environments. For more information, please see our <a href="/docs">Documentation</a>, <a href="/discord">Discord</a> or <a href="/discuss">Discussions</a>.</p>
         <p>The project is a <i>Free and Open Source</i> game, built on <a href="http://cubeengine.com/">Cube Engine 2</a> using <a href="http://libsdl.org/">SDL</a> and <a href="http://opengl.org/">OpenGL</a> which allows it to be ported to many platforms; you can <a href="/download">download a package</a> for <i>Windows, GNU/Linux, BSD, and MacOS</i>, or <a href="/devel">grab a development</a> copy from our <a href="/github">GitHub</a> repository and live on the bleeding edge.</p>
     </div>
     <div class="col-xs-12 col-sm-4 col-md-4">


### PR DESCRIPTION
Self-explanatory. Currently clicking on "Documentation" (not in the navigation bar) will go to 404.