### PR TITLE
fix broken appimage download-link for linux/bsd

### DIFF
--- a/download/appimage/index.html
+++ b/download/appimage/index.html
@@ -2,7 +2,7 @@
 title: GNU/Linux AppImage Download
 layout: redirect
 permalink: /download/appimage
-redirect_to: https://github.com/redeclipse/deploy/releases/download/appimage_continuous_master/redeclipse-master-x86_64.AppImage
+redirect_to: https://github.com/redeclipse/deploy/releases/download/appimage_continuous_stable/redeclipse-stable-x86_64.AppImage
 redirect_from:
   - /appimage
 ---


### PR DESCRIPTION
Fixes #
Broken download link of the AppImage for Linux/BSD on https://www.redeclipse.net/download

Changes proposed in this request:
- update to the current link of Linux/BSD AppImage that has moved from  `appimage_continuous_master` to `appimage_continuous_stable`
