### PR TITLE
remove broken link for linux appimage

### DIFF
--- a/download/index.md
+++ b/download/index.md
@@ -15,7 +15,7 @@ Platform                                                             | Downloads
 ---------------------------------------------------------------------|-------------------------------------|-------------------------------------
 <span class="fab fa-steam" aria-hidden="true"></span> **Steam**  | **[Store Page](/steam)**      | [GameJolt](/gamejolt)
 <span class="fab fa-windows" aria-hidden="true"></span> **Windows**  | **[Installer](/download/win)**      | [Torrent](/download/torrent/win) - [ZIP](/download/zip)
-<span class="fab fa-linux" aria-hidden="true"></span> **Linux/BSD**  | **[TAR.BZ2](/download/nix)**        | [Torrent](/download/torrent/nix) - [AppImage](/download/appimage)
+<span class="fab fa-linux" aria-hidden="true"></span> **Linux/BSD**  | **[TAR.BZ2](/download/nix)**        | [Torrent](/download/torrent/nix)
 <span class="fab fa-apple" aria-hidden="true"></span> **macOS**      | **[TAR.BZ2](/download/mac)**        | [Torrent](/download/torrent/mac)
 <span class="fas fa-archive" aria-hidden="true"></span> **Combined** | **[TAR.BZ2](/download/combined)**   | [Torrent](/download/torrent/combined)
 


### PR DESCRIPTION
Fixes #
Broken link for linux appimage by simple removal

Changes proposed in this request:
- see: https://github.com/redeclipse/redeclipse.github.io/pull/8#issuecomment-1328036795
